### PR TITLE
Fix parcel at 1.12.3 because of parcel-bundler error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.0.27",
-    "parcel-bundler": "^1.12.4",
+    "parcel-bundler": "1.12.3",
     "typescript": "^3.9.7"
   }
 }


### PR DESCRIPTION
Following the chat tutorial today fails because of [a bug in parcel-bundler](https://github.com/parcel-bundler/parcel/issues/5943):

🚨  /home/oliver/Repos/pond-dependency-issue/node_modules/parcel-bundler/src/builtins/css-loader.js: Invalid Version: undefined 
    at new SemVer (/home/oliver/Repos/pond-dependency-issue/node_modules/@babel/preset-env/node_modules/semver/semver.js:314:11)
    at compare (/home/oliver/Repos/pond-dependency-issue/node_modules/@babel/preset-env/node_modules/semver/semver.js:647:10)   
    at lt (/home/oliver/Repos/pond-dependency-issue/node_modules/@babel/preset-env/node_modules/semver/semver.js:688:10)        
    at _default (/home/oliver/Repos/pond-dependency-issue/node_modules/@babel/preset-env/lib/index.js:280:22)
    at Object.default (/home/oliver/Repos/pond-dependency-issue/node_modules/@babel/helper-plugin-utils/lib/index.js:22:12)     
    at getEnvPlugins (/home/oliver/Repos/pond-dependency-issue/node_modules/parcel-bundler/src/transforms/babel/env.js:62:34)   
    at getEnvConfig (/home/oliver/Repos/pond-dependency-issue/node_modules/parcel-bundler/src/transforms/babel/env.js:12:25) )

The current workaround is to keep parcel-bundler at 1.12.3.